### PR TITLE
:art: refact: Requisições ao banco do supabase

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -71,12 +71,12 @@ export default function AuthPage() {
               duration: 0.5,
               delay: currentForm === "login" ? 0 : 0.6,
             }}
-            initial={{ y: "100%" }}
+            initial={{ y: "50%" }}
             animate={{ y: "0%" }}
-            exit={{ y: "100%" }}
+            exit={{ y: "50%" }}
             style={{
               width: "100%",
-              minHeight: "450px",
+              minHeight: "900px",
             }}
           >
             <LogInForm setCurrentForm={setCurrentForm} />
@@ -89,12 +89,12 @@ export default function AuthPage() {
               duration: 0.5,
               delay: currentForm === "register" ? 0 : 0.6,
             }}
-            initial={{ y: "100%" }}
+            initial={{ y: "50%" }}
             animate={{ y: "0%" }}
-            exit={{ y: "100%" }}
+            exit={{ y: "50%" }}
             style={{
               width: "100%",
-              minHeight: "450px",
+              minHeight: "900px",
             }}
           >
             <RegisterForm />

--- a/src/components/Forms/AddProductForm.tsx
+++ b/src/components/Forms/AddProductForm.tsx
@@ -24,10 +24,9 @@ import { sendToastMessage } from "@/functions/sendToastMessage";
 export const AddProductForm = () => {
   const user = useGeneralUserStore((store) => store.user);
 
-  const { fetchData } = useContext(ProductsContext);
+  const { setData } = useContext(ProductsContext);
   const {
     register,
-    watch,
     control,
     formState: { errors },
     reset,
@@ -37,6 +36,7 @@ export const AddProductForm = () => {
   // funções
   async function onSubmit(data: IFormItem) {
     const item = {
+      id: crypto.randomUUID(),
       ...data,
       user_id: user?.id,
     };
@@ -58,7 +58,9 @@ export const AddProductForm = () => {
           type: "success"
         });
 
-        fetchData();
+        // atualiza estado de produtos após atualizar banco
+        setData(previous => [...previous!, item]);
+        // fetchData();
       }
 
       reset()

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -95,7 +95,7 @@ const FormLabel = React.forwardRef<
   return (
     <Label
       ref={ref}
-      className={cn(error && "text-destructive", "text-[#212121] font-semibold text-sm", className)}
+      className={cn(error && "text-destructive", "text-subtitle font-semibold text-sm", className)}
       htmlFor={formItemId}
       {...props}
     />

--- a/src/context/PageOverlayContext.tsx
+++ b/src/context/PageOverlayContext.tsx
@@ -1,7 +1,7 @@
 import OverlayEffect from "@/components/OverlayEffect";
 import { sleep } from "@/functions/sleep";
-import { useRouter } from "next/navigation";
-import { createContext, useContext, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { createContext, useContext, useEffect, useState } from "react";
 
 type PageOverlayProps = {
     isChangingRoute: boolean,
@@ -13,16 +13,27 @@ const PageOverlayContext = createContext<PageOverlayProps | null>(null);
 export const PageOverlayProvider = ({ children }: { children: React.ReactNode }) => {
 
     const [isChangingRoute, setIsChangingRoute] = useState<boolean>(false);
+    const [currentRoute, setCurrentRoute] = useState<string>("");
     const router = useRouter();
+    const pathname = usePathname();
 
     async function handleChangeRoute(route: string) {
         if (window.location.pathname === route) return;
         setIsChangingRoute(true);
-        await sleep(0.3)
         router.push(route);
-        await sleep(1)
-        setIsChangingRoute(false);
     }
+
+    useEffect(() => {
+        async function changeRoute() {
+            if (currentRoute !== pathname) {
+                await sleep(0.5);
+                setIsChangingRoute(false);
+                setCurrentRoute(pathname);
+            }
+        }
+        changeRoute();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [pathname]);
 
     return (
         <PageOverlayContext.Provider value={{ isChangingRoute, handleChangeRoute }}>


### PR DESCRIPTION
# 📝 Descição:

A cada adição de um novo produto, uma request era feita para o banco de dados para pegar os dados novos. Esse comportamento se dava ao fato de que o próprio supabase gerava o UUID do produto, que era necessário em um caso de deleção/edição.

Foi inserida a API nativa `crypto`, que cria UUIDs de forma randômica, eliminando a necessidade do backend precisar criar um.

Agora a adição do item, além de ser feita na db, é feita diretamente no estado, melhorando a performance do aplicativo e retirando uma carga do banco de dados.

### ⚙️ Outras modificações:

- Cor da label alterada para ser modificada conforme tema escolhido (não inclui tela de auth ou início)

- Aumentada altura dos forms de Login/Registro, e diminuído a animação do eixo Y em 50%.

- Lógica do `PageOverlayContext` modificada para só retirar o overlay após `0.5` segundos a mudança de rota.